### PR TITLE
Upgrade Java and dependencies, update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
 
+## v1.1.0
+
+### Changed
+- Upgraded Java to version 25
+- Upgraded Spring Boot from 3.3.5 to 3.5.9
+- Upgraded Spring AI from 1.0.3 to 1.1.1
+- Removed Snyk integration from the project
+- Updated documentation to reflect current versions
+
 ## v1.0.0
 
 ### Added or Changed
 - Added this changelog :)
 - Added Spring AI (OpenAI)
-- Added PDF reader capabilities from Sprig AI 
+- Added PDF reader capabilities from Sprig AI
 - Added README.md

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The goal was to practice. I read on spring ai and also watched YouTube all descr
 
 ### Technological stack
 * Java 25 (OpenJDK)
-* Spring Boot 3.4.2 (Latest stable release)
-* Spring AI 1.0.3 (Latest stable as of October 2025)
+* Spring Boot 3.5.9 (Latest stable release as of December 2025)
+* Spring AI 1.1.1 (Latest stable as of December 2025)
 * Postgresql DB + PGVector ([Postgres Vector extension](https://www.postgresql.org/about/news/pgvector-050-released-2700/))
 
 ### Before you start

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.5.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.mytrail</groupId>
@@ -20,7 +20,7 @@
     <description>my ai trail</description>
     <properties>
         <java.version>25</java.version>
-        <spring-ai.version>1.0.3</spring-ai.version>
+        <spring-ai.version>1.1.1</spring-ai.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Upgrade Spring Boot from 3.3.5 to 3.5.9
- Upgrade Spring AI from 1.0.3 to 1.1.1
- Update documentation to reflect current versions (December 2025)
- Java 25 already configured